### PR TITLE
Add Jekyll build workflow

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -1,0 +1,18 @@
+name: Jekyll Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:3.1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Jekyll
+        run: gem install jekyll
+      - name: Build site
+        run: jekyll build


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow using a Ruby container
- install Jekyll and run `jekyll build` on each push or pull request

## Testing
- `gem install jekyll` *(fails: 403 Forbidden)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ba0fbdf4832395a1f4bed6a15d0a