### PR TITLE
Remove references to missing social images

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,7 +22,6 @@
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="{{ page.title | default: site.title }}">
     <meta property="og:description" content="Tommaso's portfolio showcasing projects, blog, and more.">
-    <meta property="og:image" content="{{ '/assets/images/og-image.png' | relative_url }}">
     <meta property="og:url" content="{{ page.url | relative_url }}">
     <meta property="og:type" content="website">
 
@@ -30,7 +29,6 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{ page.title | default: site.title }}">
     <meta name="twitter:description" content="Tommaso's portfolio showcasing projects, blog, and more.">
-    <meta name="twitter:image" content="{{ '/assets/images/twitter-image.png' | relative_url }}">
 
     <!-- Schema.org Structured Data -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- remove meta tags for missing Open Graph and Twitter card images in `default.html`

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442a6941448323919f4fcd42bff0d2