### PR TITLE
Improve alt text for profile image

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -4,7 +4,7 @@ layout: default
 ---
 
 
-<img src="assets/images/IMG_4406.jpeg" alt=" Photo" class="profile-pic">
+<img src="assets/images/IMG_4406.jpeg" alt="Tommaso Vaccari profile picture" class="profile-pic">
 
 <section id="Biography">
     <h2>Biography</h2>


### PR DESCRIPTION
## Summary
- make alt text describe profile image clearly

## Testing
- `grep -n "profile picture" -n index.markdown`

------
https://chatgpt.com/codex/tasks/task_e_68442a645d4c832387e3b325a2d7a7e2